### PR TITLE
Update solidworks-install.sh/Prevent partial upgrades on pacman based systems

### DIFF
--- a/scripts/stable-branch/solidworks-install.sh
+++ b/scripts/stable-branch/solidworks-install.sh
@@ -73,7 +73,7 @@ elif VERB="$( which dnf )" 2> /dev/null; then
    sudo dnf install dialog wmctrl
 elif VERB="$( which pacman )" 2> /dev/null; then
    echo "Arch-based"
-   sudo pacman -Sy --needed dialog wmctrl
+   sudo pacman -Syu --needed dialog wmctrl
 elif VERB="$( which zypper )" 2> /dev/null; then
    echo "openSUSE-based"
    su -c 'zypper up && zypper install dialog wmctrl'
@@ -299,7 +299,7 @@ esac
 }
 
 function archlinux-2 {
-   sudo pacman -Sy --needed wine wine-mono wine_gecko winetricks p7zip curl cabextract samba ppp
+   sudo pacman -Syu --needed wine wine-mono wine_gecko winetricks p7zip curl cabextract samba ppp
 }
    
 function debian-based-1 {


### PR DESCRIPTION
Partial upgrades are unsupported on pacman based distributions, either use -S or -Syu.
In this case, I think -Syu is better as we want the user to have an up to date system when installing.