### PR TITLE
Update solidworks-install.sh to not clutter /etc/pacman.conf on Arch-Based distros

### DIFF
--- a/scripts/stable-branch/solidworks-install.sh
+++ b/scripts/stable-branch/solidworks-install.sh
@@ -72,7 +72,7 @@ elif VERB="$( which dnf )" 2> /dev/null; then
    sudo dnf install dialog wmctrl
 elif VERB="$( which pacman )" 2> /dev/null; then
    echo "Arch-based"
-   sudo pacman -Syu --needed dialog wmctrl
+   sudo pacman -Syu --needed dialog wmctrl grep gawk
 elif VERB="$( which zypper )" 2> /dev/null; then
    echo "openSUSE-based"
    su -c 'zypper up && zypper install dialog wmctrl'

--- a/scripts/stable-branch/solidworks-install.sh
+++ b/scripts/stable-branch/solidworks-install.sh
@@ -289,8 +289,13 @@ case $CHOICE in
             selectyourpath
             ;;
         2)
-            sudo echo "[multilib]" >> /etc/pacman.conf &&
-            sudo echo "Include = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf &&
+            if grep -q "#[multilib]" /etc/pacman.conf
+            then
+            echo "multilib already enabled, not writing to /etc/pacman.conf"
+            else
+            echo "multilib is not enabled, enabling it now"
+            sudo awk -v RS="\0" -v ORS="" '{gsub(/#\[multilib\]\n#Include = \/etc\/pacman.d\/mirrorlist/,"[multilib]\nInclude = /etc/pacman.d/mirrorlist")}7' /etc/pacman.conf > /dev/null
+            fi
             archlinux2 &&
             selectyourpath
             ;;


### PR DESCRIPTION
Switched from appending
```
[multilib]
Include = /etc/pacman.d/mirrorlist
```
to `/etc/pacman.conf` every time the script runs. It now checks to see if the text is present, and if it is, skips editing the file. It also no longer appends, but edits the entries in place using `awk`, keeping in line with `/etc/pacman.conf`'s formatting.