### PR TITLE
Incorrect directory for winetricks

### DIFF
--- a/files/builds/stable-branch/bin/install.sh
+++ b/files/builds/stable-branch/bin/install.sh
@@ -480,7 +480,7 @@ function OS_GENTOO_LINUX {
 ###############################################################################################################################################################
 
 function SP_SOLIDWORKS_INSTALL {
-   cd "$SP_PATH/bin/winetricks"
+   cd "$SP_PATH/bin/"
    WINEPREFIX=$SP_PATH/wineprefixes/solidworks sh winetricks -q atmlib gdiplus corefonts msxml4 msxml6 vcrun2019 ie8 dxvk win10 &&
    WINEPREFIX=$SP_PATH/wineprefixes/solidworks sh winetricks -q win10 &&
    cd "$SP_PATH/downloads/extensions" &&


### PR DESCRIPTION
There was a cd to the winetricks binary, `cd $SP_PATH/bin/winetricks` instead of the containing directory, `cd $SP_PATH/bin/`. This was causing my install to fail whilst in a toolbox container since winetricks is not installed globally. 